### PR TITLE
Sending Gray + - * to cmdline if not empty

### DIFF
--- a/far2l/src/panels/filelist.cpp
+++ b/far2l/src/panels/filelist.cpp
@@ -1008,11 +1008,21 @@ int FileList::ProcessKey(FarKey Key)
 			return TRUE;
 		}
 		case KEY_ADD:
-			SelectFiles(SELECT_ADD);
-			return TRUE;
 		case KEY_SUBTRACT:
-			SelectFiles(SELECT_REMOVE);
+		case KEY_MULTIPLY: {
+			if (CmdIsNotEmpty)
+				return FALSE;
+
+			int Mode = SELECT_ADD;
+
+			if (Key == KEY_SUBTRACT)
+				Mode = SELECT_REMOVE;
+			else if (Key == KEY_MULTIPLY)
+				Mode = SELECT_INVERT;
+
+			SelectFiles(Mode);
 			return TRUE;
+		}
 		case KEY_CTRLADD:
 			SelectFiles(SELECT_ADDEXT);
 			return TRUE;
@@ -1024,9 +1034,6 @@ int FileList::ProcessKey(FarKey Key)
 			return TRUE;
 		case KEY_ALTSUBTRACT:
 			SelectFiles(SELECT_REMOVENAME);
-			return TRUE;
-		case KEY_MULTIPLY:
-			SelectFiles(SELECT_INVERT);
 			return TRUE;
 		case KEY_CTRLMULTIPLY:
 			SelectFiles(SELECT_INVERTALL);
@@ -2133,9 +2140,7 @@ int FileList::ProcessKey(FarKey Key)
 		default:
 
 			if ((Key == L'*') || (Key == L'+') || (Key == L'-')) {
-				FARString TmpStr;
-				CtrlObject->CmdLine->GetString(TmpStr);
-				if (TmpStr.IsEmpty()) {
+				if (!CmdIsNotEmpty) {
 					if (Key == L'*') {
 						SelectFiles(SELECT_INVERT);
 						return TRUE;


### PR DESCRIPTION
Fix #3389

вот тут было обсуждение #2852 по похожей теме. Думаю, стоит ориентироваться на пользователя, который печатает g++, а не на редкого гостя, который помнит, что именно на numpad арифметические операции что-то селектят, тогда как обычные + - * в верхнем ряду клавиш вводят текст в командную строку после #2311
Пусть оба плюсика ведут себя одинаково.

https://github.com/elfmz/far2l/pull/3390

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved hotkey handling logic for file selection operations, consolidating redundant code paths for better maintainability.
  * Optimized quick-key command-line processing to streamline internal checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->