### PR TITLE
adb: silence -Wunused for DBG-only vars; fix dangling ColumnTitles

### DIFF
--- a/adb/src/ADBDevice.cpp
+++ b/adb/src/ADBDevice.cpp
@@ -622,11 +622,13 @@ int ADBDevice::TransferItem(const std::string& src, const std::string& dst, bool
     }
 
     int errno_mapped = Str2Errno(result);
+#if defined(DEBUG) || defined(_DEBUG)
     const size_t tail_len = std::min<size_t>(result.size(), 400);
     const char* tail = result.c_str() + (result.size() - tail_len);
     DBG("TransferItem FAIL is_push=%d pty_exit=%d errno=%d src='%s' dst='%s' tail[%zu]='%.*s'\n",
         is_push, ADBShell::lastPtyExit(), errno_mapped, src.c_str(), dst.c_str(),
         tail_len, (int)tail_len, tail);
+#endif
     return errno_mapped;
 }
 

--- a/adb/src/ADBDevice.cpp
+++ b/adb/src/ADBDevice.cpp
@@ -623,7 +623,7 @@ int ADBDevice::TransferItem(const std::string& src, const std::string& dst, bool
 
     int errno_mapped = Str2Errno(result);
     const size_t tail_len = std::min<size_t>(result.size(), 400);
-    [[maybe_unused]] const char* tail = result.c_str() + (result.size() - tail_len);
+    const char* tail = result.c_str() + (result.size() - tail_len);
     DBG("TransferItem FAIL is_push=%d pty_exit=%d errno=%d src='%s' dst='%s' tail[%zu]='%.*s'\n",
         is_push, ADBShell::lastPtyExit(), errno_mapped, src.c_str(), dst.c_str(),
         tail_len, (int)tail_len, tail);

--- a/adb/src/ADBDevice.cpp
+++ b/adb/src/ADBDevice.cpp
@@ -623,7 +623,7 @@ int ADBDevice::TransferItem(const std::string& src, const std::string& dst, bool
 
     int errno_mapped = Str2Errno(result);
     const size_t tail_len = std::min<size_t>(result.size(), 400);
-    const char* tail = result.c_str() + (result.size() - tail_len);
+    [[maybe_unused]] const char* tail = result.c_str() + (result.size() - tail_len);
     DBG("TransferItem FAIL is_push=%d pty_exit=%d errno=%d src='%s' dst='%s' tail[%zu]='%.*s'\n",
         is_push, ADBShell::lastPtyExit(), errno_mapped, src.c_str(), dst.c_str(),
         tail_len, (int)tail_len, tail);

--- a/adb/src/ADBLog.h
+++ b/adb/src/ADBLog.h
@@ -16,13 +16,13 @@ void DebugLog(const char *format, ...);
 }
 #endif
 
-// Debug macros - completely absent from release builds; enable with -DDEBUG.
+// In release DBG(...) discards its arguments at the preprocessor level, so
+// DBG-only variables can be guarded with `#if defined(DEBUG) || defined(_DEBUG)`
+// at the call site without wrapping the DBG call itself.
 #if defined(DEBUG) || defined(_DEBUG)
 #define DBG(fmt, ...) DebugLog("[%s] " fmt, __FUNCTION__, ##__VA_ARGS__)
 #else
-template <typename... Args>
-constexpr void DebugLogDummy(const char *, Args &&...) noexcept {}
-#define DBG(fmt, ...) (false ? (void)DebugLogDummy((fmt), ##__VA_ARGS__) : (void)0)
+#define DBG(fmt, ...) ((void)0)
 #endif
 
 #endif // ADBLOG_H

--- a/adb/src/ADBLog.h
+++ b/adb/src/ADBLog.h
@@ -16,11 +16,13 @@ void DebugLog(const char *format, ...);
 }
 #endif
 
-// Debug macros - completely absent from release builds; enable with -DDEBUG
+// Debug macros - completely absent from release builds; enable with -DDEBUG.
 #if defined(DEBUG) || defined(_DEBUG)
 #define DBG(fmt, ...) DebugLog("[%s] " fmt, __FUNCTION__, ##__VA_ARGS__)
 #else
-#define DBG(fmt, ...) ((void)0)
+template <typename... Args>
+constexpr void DebugLogDummy(const char *, Args &&...) noexcept {}
+#define DBG(fmt, ...) (false ? (void)DebugLogDummy((fmt), ##__VA_ARGS__) : (void)0)
 #endif
 
 #endif // ADBLOG_H

--- a/adb/src/ADBPlugin.cpp
+++ b/adb/src/ADBPlugin.cpp
@@ -489,7 +489,11 @@ void ADBPlugin::GetOpenPluginInfo(OpenPluginInfo *Info)
 		.Reserved           = {0, 0}
 	};
 
-	const wchar_t* connectedTitles[] = { Lng(MColName), Lng(MColSize) };
+	// Static storage so the pointer stored in `connectedMode.ColumnTitles` outlives this call;
+	// values refreshed on every invocation so language changes are picked up.
+	static const wchar_t* connectedTitles[2];
+	connectedTitles[0] = Lng(MColName);
+	connectedTitles[1] = Lng(MColSize);
 
 	static PanelMode deviceMode = {
 		.ColumnTypes        = L"N,C0,C1,C2",
@@ -504,7 +508,12 @@ void ADBPlugin::GetOpenPluginInfo(OpenPluginInfo *Info)
 		.Reserved           = {0, 0}
 	};
 
-	const wchar_t* deviceTitles[] = { Lng(MColSerial), Lng(MColDeviceName), Lng(MColModel), Lng(MColPort) };
+	// See note above on connectedTitles — same lifetime requirement.
+	static const wchar_t* deviceTitles[4];
+	deviceTitles[0] = Lng(MColSerial);
+	deviceTitles[1] = Lng(MColDeviceName);
+	deviceTitles[2] = Lng(MColModel);
+	deviceTitles[3] = Lng(MColPort);
 
 	if (_isConnected) {
 		connectedMode.ColumnTitles = connectedTitles;
@@ -2410,7 +2419,7 @@ std::map<std::string, ADBPlugin::DirMeta> ADBPlugin::PrescanDeviceDirs(const std
 	auto t0 = std::chrono::steady_clock::now();
 	std::map<std::string, std::unordered_map<std::string, uint64_t>> raw;
 	_adbDevice->BatchDirectoryFileSizes(dirs, raw);
-	uint64_t total_files = 0, total_bytes = 0;
+	[[maybe_unused]] uint64_t total_files = 0, total_bytes = 0;
 	for (auto& kv : raw) {
 		DirMeta dm;
 		dm.file_sizes = std::move(kv.second);
@@ -2420,7 +2429,7 @@ std::map<std::string, ADBPlugin::DirMeta> ADBPlugin::PrescanDeviceDirs(const std
 		total_bytes += dm.total_size;
 		out[kv.first] = std::move(dm);
 	}
-	auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+	[[maybe_unused]] auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
 		std::chrono::steady_clock::now() - t0).count();
 	DBG("PrescanDeviceDirs dirs=%zu out=%zu files=%llu bytes=%llu in %lldms\n",
 		dirs.size(), out.size(), (unsigned long long)total_files,

--- a/adb/src/ADBPlugin.cpp
+++ b/adb/src/ADBPlugin.cpp
@@ -2416,24 +2416,32 @@ std::map<std::string, ADBPlugin::DirMeta> ADBPlugin::PrescanDeviceDirs(const std
 {
 	std::map<std::string, DirMeta> out;
 	if (dirs.empty() || !_isConnected || !_adbDevice) return out;
+#if defined(DEBUG) || defined(_DEBUG)
 	auto t0 = std::chrono::steady_clock::now();
+#endif
 	std::map<std::string, std::unordered_map<std::string, uint64_t>> raw;
 	_adbDevice->BatchDirectoryFileSizes(dirs, raw);
+#if defined(DEBUG) || defined(_DEBUG)
 	uint64_t total_files = 0, total_bytes = 0;
+#endif
 	for (auto& kv : raw) {
 		DirMeta dm;
 		dm.file_sizes = std::move(kv.second);
 		dm.file_count = dm.file_sizes.size();
 		for (const auto& fk : dm.file_sizes) dm.total_size += fk.second;
+#if defined(DEBUG) || defined(_DEBUG)
 		total_files += dm.file_count;
 		total_bytes += dm.total_size;
+#endif
 		out[kv.first] = std::move(dm);
 	}
+#if defined(DEBUG) || defined(_DEBUG)
 	auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
 		std::chrono::steady_clock::now() - t0).count();
 	DBG("PrescanDeviceDirs dirs=%zu out=%zu files=%llu bytes=%llu in %lldms\n",
 		dirs.size(), out.size(), (unsigned long long)total_files,
 		(unsigned long long)total_bytes, (long long)ms);
+#endif
 	if (out.size() < dirs.size()) {
 		DBG("PrescanDeviceDirs WARN missing %zu dir(s) — totals will fallback to 0/0\n",
 			dirs.size() - out.size());

--- a/adb/src/ADBPlugin.cpp
+++ b/adb/src/ADBPlugin.cpp
@@ -2419,7 +2419,7 @@ std::map<std::string, ADBPlugin::DirMeta> ADBPlugin::PrescanDeviceDirs(const std
 	auto t0 = std::chrono::steady_clock::now();
 	std::map<std::string, std::unordered_map<std::string, uint64_t>> raw;
 	_adbDevice->BatchDirectoryFileSizes(dirs, raw);
-	[[maybe_unused]] uint64_t total_files = 0, total_bytes = 0;
+	uint64_t total_files = 0, total_bytes = 0;
 	for (auto& kv : raw) {
 		DirMeta dm;
 		dm.file_sizes = std::move(kv.second);
@@ -2429,7 +2429,7 @@ std::map<std::string, ADBPlugin::DirMeta> ADBPlugin::PrescanDeviceDirs(const std
 		total_bytes += dm.total_size;
 		out[kv.first] = std::move(dm);
 	}
-	[[maybe_unused]] auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+	auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
 		std::chrono::steady_clock::now() - t0).count();
 	DBG("PrescanDeviceDirs dirs=%zu out=%zu files=%llu bytes=%llu in %lldms\n",
 		dirs.size(), out.size(), (unsigned long long)total_files,

--- a/adb/src/ProgressBatch.cpp
+++ b/adb/src/ProgressBatch.cpp
@@ -212,7 +212,9 @@ BatchResult RunBatch(const std::wstring& title,
 
 	op.Run([&](ProgressState& state) {
 		uint64_t bytes_done = 0, files_done = 0;
+#if defined(DEBUG) || defined(_DEBUG)
 		size_t unit_idx = 0;
+#endif
 		try {
 			for (auto& u : units) {
 				if (state.ShouldAbort()) { result.aborted = true; break; }

--- a/adb/src/ProgressBatch.cpp
+++ b/adb/src/ProgressBatch.cpp
@@ -212,7 +212,7 @@ BatchResult RunBatch(const std::wstring& title,
 
 	op.Run([&](ProgressState& state) {
 		uint64_t bytes_done = 0, files_done = 0;
-		[[maybe_unused]] size_t unit_idx = 0;
+		size_t unit_idx = 0;
 		try {
 			for (auto& u : units) {
 				if (state.ShouldAbort()) { result.aborted = true; break; }

--- a/adb/src/ProgressBatch.cpp
+++ b/adb/src/ProgressBatch.cpp
@@ -212,7 +212,7 @@ BatchResult RunBatch(const std::wstring& title,
 
 	op.Run([&](ProgressState& state) {
 		uint64_t bytes_done = 0, files_done = 0;
-		size_t unit_idx = 0;
+		[[maybe_unused]] size_t unit_idx = 0;
 		try {
 			for (auto& u : units) {
 				if (state.ShouldAbort()) { result.aborted = true; break; }


### PR DESCRIPTION
4 warnings reported in #3404 + 2 same-pattern variants caught locally on clang.

* ms, tail, unit_idx, total_files/total_bytes: live only inside DBG(...), which expands to ((void)0) in release. Marked [[maybe_unused]] — same idiom as 8f6814a (mtp).
* GetOpenPluginInfo: connectedTitles/deviceTitles were local arrays whose addresses were stored in static PanelMode::ColumnTitles, dangling after return. Made arrays static, refilled per call so language switches still pick up new translations.

Fixes https://github.com/elfmz/far2l/issues/3404


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed plugin panel column titles to properly persist and reflect language changes.

* **Chores**
  * Improved release build performance by conditionally compiling debug-only logging and diagnostic code.
  * Enhanced documentation clarifying debug macro behavior across build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->