### PR TITLE
Arclite parameters only '-'

### DIFF
--- a/arclite/src/cmdline.cpp
+++ b/arclite/src/cmdline.cpp
@@ -119,7 +119,7 @@ struct Param
 
 static bool is_param(const std::wstring &param_str)
 {
-	return !param_str.empty() && (param_str[0] == L'-' || param_str[0] == L'/');
+	return !param_str.empty() && (param_str[0] == L'-'/* || param_str[0] == L'/'*/);
 }
 
 static Param parse_param(const std::wstring &param_str)


### PR DESCRIPTION
Fix https://github.com/elfmz/far2l/issues/3423

https://github.com/elfmz/far2l/pull/3427

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Command-line parameter recognition now only accepts `-` prefixed options. Support for `/` prefixed options has been removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->