### PR TITLE
fix(tty,vt): prevent deadlocks and hangs in terminal backend

### DIFF
--- a/WinPort/src/Backend/TTY/TTYBackend.cpp
+++ b/WinPort/src/Backend/TTY/TTYBackend.cpp
@@ -3,6 +3,7 @@
 #include <signal.h>
 #include <fcntl.h>
 #include <exception>
+#include <chrono>
 #include <sys/ioctl.h>
 
 #ifdef __linux__
@@ -31,6 +32,13 @@
 static uint16_t g_far2l_term_width = 80, g_far2l_term_height = 25;
 static volatile long s_terminal_size_change_id = 0;
 static TTYBackend * g_vtb = nullptr;
+
+static std::atomic<bool> s_parent_dead{false};
+
+static void OnParentDead(int)
+{
+	s_parent_dead.store(true, std::memory_order_relaxed);
+}
 
 long _iterm2_cmd_ts = 0;
 bool _iterm2_cmd_state = 0;
@@ -86,6 +94,7 @@ TTYBackend::TTYBackend(const char *full_exe_path, int std_in, int std_out, bool 
 	_ext_clipboard(ext_clipboard),
 	_restrict(restrict),
 	_esc_expiration(esc_expiration),
+	_is_forktty_child(notify_pipe != -1),
 	_notify_pipe(notify_pipe),
 	_result(result),
 	_largest_window_size_ready(false)
@@ -306,7 +315,21 @@ void TTYBackend::ReaderThread()
 					break;
 				}
 				usleep(10000);
+				if (_is_forktty_child && s_parent_dead.load(std::memory_order_relaxed)) {
+					fprintf(stderr, "TTYBackend::ReaderThread: parent gone during suspend, exiting\n");
+					_exiting = true;
+					WINPORT(GenerateConsoleCtrlEvent)(CTRL_CLOSE_EVENT, 0);
+					break;
+				}
 			} else {
+				// If the parent session manager (ForkTTYChild wrapper) is gone,
+				// no one will ever connect for revival — exit gracefully.
+				if (_is_forktty_child && s_parent_dead.load(std::memory_order_relaxed)) {
+					fprintf(stderr, "TTYBackend::ReaderThread: parent gone, exiting\n");
+					_exiting = true;
+					WINPORT(GenerateConsoleCtrlEvent)(CTRL_CLOSE_EVENT, 0);
+					break;
+				}
 				const std::string &info = StrWide2MB(g_winport_con_out->GetTitle());
 				int np = TTYReviveMe(_stdin, _stdout, _kickass[0], info);
 				if (np != -1) {
@@ -465,7 +488,9 @@ void TTYBackend::WriterThread()
 			}
 
 			tty_out.Flush();
-			tcdrain(_stdout);
+			if (!_exiting && !_deadio) {
+				tcdrain(_stdout);
+			}
 
 			if (ae.go_background) {
 				gone_background = true;
@@ -693,6 +718,7 @@ void TTYBackend::DispatchFar2lInteract(TTYOutput &tty_out)
 			}
 		}
 		i->stk_ser.PushNum(id);
+		i->id = id;
 
 		if (i->waited)
 			_far2l_interacts_sent.emplace(id, i);
@@ -1020,7 +1046,7 @@ void TTYBackend::OSC52SetClipboard(const char *text)
 
 bool TTYBackend::Far2lInteract(StackSerializer &stk_ser, bool wait)
 {
-	if (_tty_caps.kind != TTYCaps::FAR2L || _exiting)
+	if (_tty_caps.kind != TTYCaps::FAR2L || _exiting || _deadio)
 		return false;
 
 	std::shared_ptr<Far2lInteractData> pfi = std::make_shared<Far2lInteractData>();
@@ -1037,10 +1063,28 @@ bool TTYBackend::Far2lInteract(StackSerializer &stk_ser, bool wait)
 	if (!wait)
 		return true;
 
-	pfi->evnt.Wait();
+	static constexpr unsigned int FAR2L_INTERACT_TIMEOUT_MSEC = 10000;
+	static constexpr unsigned int FAR2L_INTERACT_POLL_MSEC = 500;
+	const auto deadline = std::chrono::steady_clock::now()
+		+ std::chrono::milliseconds(FAR2L_INTERACT_TIMEOUT_MSEC);
+	bool completed = false;
+	while (!completed) {
+		completed = pfi->evnt.TimedWait(FAR2L_INTERACT_POLL_MSEC);
+		if (completed || _exiting || _deadio)
+			break;
+		if (std::chrono::steady_clock::now() >= deadline) {
+			fprintf(stderr, "TTYBackend::Far2lInteract: timeout\n");
+			if (pfi->id) {
+				std::lock_guard<std::mutex> lock_sent(_far2l_interacts_sent);
+				_far2l_interacts_sent.erase(pfi->id);
+			}
+			pfi->stk_ser.Swap(stk_ser);
+			return false;
+		}
+	}
 
 	std::unique_lock<std::mutex> lock_sent(_far2l_interacts_sent);
-	if (_exiting)
+	if (_exiting || _deadio)
 		return false;
 
 	pfi->stk_ser.Swap(stk_ser);
@@ -1431,6 +1475,7 @@ static void OnSigHup(int signo)
 	}
 }
 
+
 void TTYBackend::OnSigHup()
 {
 	// drop sudo privileges once pending sudo operation completes
@@ -1656,15 +1701,17 @@ bool WinPortMainTTY(const char *full_exe_path, int std_in, int std_out,
 	auto orig_tstp = signal(SIGTSTP, OnSigTstp);
 	auto orig_cont = signal(SIGCONT, OnSigCont);
 	auto orig_hup = signal(SIGHUP, (notify_pipe != -1) ? OnSigHup : SIG_DFL); // notify_pipe == -1 means --mortal specified
+	auto orig_usr1 = signal(SIGUSR1, (notify_pipe != -1) ? OnParentDead : SIG_DFL);
 
 	*result = 0; // set OK status for case if app will go background
 	*result = AppMain(argc, argv);
 
 	signal(SIGHUP, orig_hup);
-	signal(SIGCONT, orig_tstp);
-	signal(SIGTSTP, orig_cont);
+	signal(SIGCONT, orig_cont);
+	signal(SIGTSTP, orig_tstp);
 	signal(SIGWINCH, orig_winch);
 	signal(SIGTERM, orig_term);
+	signal(SIGUSR1, orig_usr1);
 
 	return true;
 }

--- a/WinPort/src/Backend/TTY/TTYBackend.h
+++ b/WinPort/src/Backend/TTY/TTYBackend.h
@@ -45,6 +45,7 @@ class TTYBackend : IConsoleOutputBackend, ITTYInputSpecialSequenceHandler, IFar2
 	bool _ext_clipboard = false;
 	TTYRestrict _restrict{};
 	unsigned int _esc_expiration = 0;
+	bool _is_forktty_child = false;
 	int _notify_pipe = -1;
 	int *_result = nullptr;
 	int _kickass[2] = {-1, -1};
@@ -56,8 +57,8 @@ class TTYBackend : IConsoleOutputBackend, ITTYInputSpecialSequenceHandler, IFar2
 	long _terminal_size_change_id = 0;
 
 	pthread_t _reader_trd = 0;
-	volatile bool _exiting = false;
-	volatile bool _deadio = false;
+	std::atomic<bool> _exiting{false};
+	std::atomic<bool> _deadio{false};
 
 	static void *sReaderThread(void *p) { ((TTYBackend *)p)->ReaderThread(); return nullptr; }
 	static void *sWriterThread(void *p) { ((TTYBackend *)p)->WriterThread(); return nullptr; }
@@ -96,6 +97,7 @@ class TTYBackend : IConsoleOutputBackend, ITTYInputSpecialSequenceHandler, IFar2
 		Event evnt;
 		StackSerializer stk_ser;
 		bool waited;
+		uint8_t id = 0; // assigned in DispatchFar2lInteract; used by timeout path to erase from _far2l_interacts_sent
 	};
 
 	struct Far2lInteractV : std::vector<std::shared_ptr<Far2lInteractData> > {} _far2l_interacts_queued;

--- a/WinPort/src/Backend/TTY/TTYRevive.cpp
+++ b/WinPort/src/Backend/TTY/TTYRevive.cpp
@@ -115,10 +115,6 @@ int TTYReviveMe(int std_in, int std_out, int kickass, const std::string &info)
 	} catch (LocalSocketCancelled &e) {
 		(void)e;
 		fprintf(stderr, "TTYReviveMe: kickass signalled\n");
-		char c;
-		if (read(kickass, &c, 1) < 0) {
-			perror("read kickass");
-		}
 
 	} catch (std::exception &e) {
 		fprintf(stderr, "TTYReviveMe: %s\n", e.what());

--- a/WinPort/src/Backend/WinPortMain.cpp
+++ b/WinPort/src/Backend/WinPortMain.cpp
@@ -12,9 +12,11 @@
 # include <termios.h>
 # include <linux/kd.h>
 # include <linux/keyboard.h>
+# include <sys/prctl.h>
 #elif defined(__FreeBSD__) || defined(__DragonFly__)
 # include <sys/ioctl.h>
 # include <sys/kbio.h>
+# include <sys/procctl.h>
 #endif
 
 #include <ScopeHelpers.h>
@@ -560,6 +562,25 @@ extern "C" int WinPortMain(const char *full_exe_path, int argc, char **argv, int
 				MakeFDCloexec(std_out);
 				MakeFDCloexec(new_notify_pipe[1]);
 				if (g_sigwinch_pid == 0) {
+					// Register SIGUSR1 as default here; the real parent-death
+					// handler is installed in WinPortMainTTY (TTYBackend.cpp).
+					// PR_SET_PDEATHSIG / PROC_PDEATHSIG_CTL asks the kernel to
+					// deliver SIGUSR1 when our parent dies.
+					signal(SIGUSR1, SIG_DFL);
+#ifdef __linux__
+					prctl(PR_SET_PDEATHSIG, SIGUSR1);
+#elif defined(__FreeBSD__) || defined(__DragonFly__)
+					int sig = SIGUSR1;
+					procctl(P_PID, 0, PROC_PDEATHSIG_CTL, &sig);
+#endif
+					// Close the fork-to-prctl race window: if the parent died
+					// between fork() and the prctl/procctl above, we are already
+					// reparented to init/subreaper (getppid()==1) and no signal
+					// will ever fire. Exit immediately in that case.
+					if (getppid() == 1) {
+						fprintf(stderr, "WinPortMain: parent already gone at fork, exiting\n");
+						_exit(EXIT_FAILURE);
+					}
 					{
 						setsid();
 						SudoAskpassImpl askass_impl;

--- a/far2l/src/console/keyboard.cpp
+++ b/far2l/src/console/keyboard.cpp
@@ -34,6 +34,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "headers.hpp"
 
 #include <ctype.h>
+#include "InterThreadCall.hpp"
 #include "keyboard.hpp"
 #include "farqueue.hpp"
 #include "lang.hpp"
@@ -708,6 +709,12 @@ static DWORD GetInputRecordInner(INPUT_RECORD *rec, bool ExcludeMacro, bool Proc
 			}
 
 #endif
+			if (rec->EventType == NOOP_EVENT) {
+				Console.ReadInput(*rec);
+				DispatchInterThreadCalls();
+				CheckForPendingCtrlHandleEvent();
+				break;
+			}
 			break;
 		}
 

--- a/far2l/src/vt/vtshell.cpp
+++ b/far2l/src/vt/vtshell.cpp
@@ -530,28 +530,45 @@ class VTShell : VTOutputReader::IProcessor, VTInputReader::IProcessor, IVTShell
 
 	void OnConsoleLog(ConsoleLogKind kind)//NB: called not from main thread!
 	{
-		std::unique_lock<std::mutex> lock(_inout_control_mutex, std::try_to_lock);
-		if (!lock) {
-			fprintf(stderr, "VTShell::OnConsoleLog: SKIPPED\n");
-			return;
+		// Two-phase lock discipline to avoid main-thread starvation:
+		//   Phase 1: lock → stop output reader → unlock.
+		//            VTA is suspended before the lock (VTAnsiSuspend RAII).
+		//            Output reader stays stopped across the InterThreadCall.
+		//   Phase 2: blocking InterThreadCall with NO mutex held —
+		//            the main thread can freely call StartIOReaders/StopIOReaders.
+		//   VTAnsiSuspend destructor fires at inner-scope exit:
+		//   VTA is resumed BEFORE the reader is restarted.
+		//   Phase 3: lock → restart output reader (only if we stopped it) → unlock.
+		bool did_stop = false;
+		{
+			VTAnsiSuspend vta_suspend(_vta);
+			if (!vta_suspend)
+				return;
+			{
+				std::lock_guard<std::mutex> lock(_inout_control_mutex);
+				if (_output_reader.IsStarted()) {
+					_output_reader.Stop();
+					did_stop = true;
+				}
+			}
+			DeliverPendingWindowInfo();
+			InterThreadCall<int>(std::bind(sShowConsoleLog, kind));
+		} // VTA resumed here, before reader restart
+		// Restart the output reader so terminal output flows again.
+		if (did_stop) {
+			std::lock_guard<std::mutex> lock(_inout_control_mutex);
+			if (!_output_reader.IsStarted()) {
+				_output_reader.Start(_fd_out);
+				if (!_output_reader.IsStarted()) {
+					fprintf(stderr, "VTShell::OnConsoleLog: failed to restart output reader\n");
+				}
+			}
 		}
-
-		//called in input thread context
-		//we're input, stop output and remember _vta state
-
-		StopAndStart<VTOutputReader> sas(_output_reader);
-		VTAnsiSuspend vta_suspend(_vta);
-		if (!vta_suspend)
-			return;
-
-		DeliverPendingWindowInfo();
-		InterThreadCall<int>(std::bind(sShowConsoleLog, kind));
 		if (!_slavename.empty())
 			UpdateTerminalSize(_fd_out);
 		if (_far2l_exts)
 			_far2l_exts->OnTerminalResized();
 	}
-
 	void OnConsoleSwitch()
 	{
 		InterThreadLockAndWake ittlaw;

--- a/far2l/src/vt/vtshell_ioreaders.h
+++ b/far2l/src/vt/vtshell_ioreaders.h
@@ -30,6 +30,8 @@ protected:
 	volatile bool  _started;
 
 	bool Start();
+	bool IsStarted() const { return _started; }
+
 	void Join();
 	virtual void OnJoin();
 	virtual void *ThreadProc() = 0;
@@ -53,6 +55,7 @@ public:
 	void Start(int fd_out = -1);
 	void Stop();
 	inline bool IsDeactivated() const { return _deactivated; }
+	inline bool IsStarted() const { return WithThread::IsStarted(); }
 	void KickAss();
 
 

--- a/utils/src/LocalSocket.cpp
+++ b/utils/src/LocalSocket.cpp
@@ -227,6 +227,10 @@ void LocalSocketServer::WaitForClient(int fd_cancel, int tmout_msec)
 
 		if (fd_cancel != -1) {
 			if (FD_ISSET(fd_cancel, &fde) || FD_ISSET(fd_cancel, &fdr)) {
+			char c;
+			if (os_call_ssize(read, fd_cancel, (void*)&c, (size_t)1) > 0) {
+				// byte consumed — prevents immediate LocalSocketCancelled rethrow
+			}
 				throw LocalSocketCancelled();
 			}
 		}


### PR DESCRIPTION
Orphan detection uses prctl(PR_SET_PDEATHSIG, SIGUSR1) instead of getppid() polling, eliminating the PID reuse race and removing a syscall every 10ms from the suspend loop. A getppid()==1 guard after prctl closes the fork-to-prctl race window where parent death between fork() and prctl() leaves the child reparented to init with no signal ever firing.

Guard tcdrain, clipboard RPC, and Far2lInteract entry with _deadio to prevent indefinite blocking on dead file descriptors during shutdown. Far2lInteract uses a 10s TimedWait with _exiting/_deadio early-out to avoid blocking when the far2l peer disconnects. The timeout path erases the orphaned entry from _far2l_interacts_sent to prevent 0xff ID-space exhaustion under slow peers.

Fix SIGTSTP/SIGCONT handler swap in WinPortMainTTY cleanup.

Two-phase lock in OnConsoleLog: release _inout_control_mutex before the blocking InterThreadCall to prevent main-thread starvation on mouse scroll during TUI app execution. Reader restart failure is now logged instead of silently freezing.

Dispatch inter-thread calls and check pending ctrl events when NOOP_EVENT is received, then break to the throttled bottom-of-loop path instead of continuing, preventing unbounded spin when a delegate dispatch re-queues NOOPs.

Drain kickass cancel byte inside LocalSocket::WaitForClient via os_call_ssize (EINTR-safe) instead of bare read in caller catch blocks to prevent rethrow loops for callers that retry after LocalSocketCancelled.

Convert s_parent_dead from volatile sig_atomic_t to std::atomic<bool> with relaxed ordering for defined cross-core visibility on weak-memory architectures. Remove dead s_pdeathsig_pending from WinPortMain.cpp (written but never read); register SIG_DFL for SIGUSR1 there since the real handler lives in WinPortMainTTY.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful shutdown coordination when parent process terminates
  * Enhanced timeout handling for inter-process communication to prevent hangs
  * Fixed console input event processing during concurrent terminal operations
  * Corrected signal handler restoration sequence to prevent handler conflicts
  * Better cleanup of inter-process interaction state on communication timeouts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->