### PR TITLE
ExecAsync: fix O(N^2) stdin write by tracking offset instead of erasing

### DIFF
--- a/utils/include/ExecAsync.h
+++ b/utils/include/ExecAsync.h
@@ -10,6 +10,7 @@ class ExecAsync : Threaded
 	std::vector<std::string> _args;
 
 	std::vector<char> _stdin, _stdout, _stderr;
+	size_t _stdin_offset{0};
 	std::mutex _mtx;
 	bool _dont_care{false};
 	bool _started{false};

--- a/utils/src/ExecAsync.cpp
+++ b/utils/src/ExecAsync.cpp
@@ -265,13 +265,22 @@ void *ExecAsync::ThreadProc()
 			fprintf(stderr, "ExecAsync: select timeout???\n");
 			continue;
 		}
-        if (in.fd[1] != -1 && FD_ISSET(in.fd[1], &write_fds)) {
-			if (_stdin.empty()) {
+		if (in.fd[1] != -1 && FD_ISSET(in.fd[1], &write_fds)) {
+			if (_stdin_offset >= _stdin.size()) {
 				CheckedCloseFD(in.fd[1]);
 			} else {
-				ssize_t r = write(in.fd[1], _stdin.data(), _stdin.size());
-				if (r > 0) {
-					_stdin.erase(_stdin.begin(), _stdin.begin() + r);
+				ssize_t nw = write(in.fd[1],
+								  _stdin.data() + _stdin_offset,
+								  _stdin.size() - _stdin_offset);
+				if (nw > 0) {
+					_stdin_offset += static_cast<size_t>(nw);
+					if (_stdin_offset >= _stdin.size()) {
+						std::vector<char>().swap(_stdin);
+						_stdin_offset = 0;
+						CheckedCloseFD(in.fd[1]);
+					}
+				} else if (nw < 0 && errno != EAGAIN && errno != EINTR) {
+					CheckedCloseFD(in.fd[1]);
 				}
 			}
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of input data sent to asynchronously executed processes.
  * Preserved pending input correctly during partial writes, reducing potential data loss and improving execution reliability.
  * Improved cleanup when input writing encounters an unrecoverable error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->